### PR TITLE
[Logout] Fixed error

### DIFF
--- a/server/app/logout.php
+++ b/server/app/logout.php
@@ -53,10 +53,9 @@ if($request['method'] == "POST")
 				else
 					// Returning the third error
 					echo error(3);
-			}
-
-			// Else if the request is empty (the user wasn't found)
-			echo error(3);
+			} else
+				// Else if the request is empty (the user wasn't found)
+				echo error(3);
 		}
 
 		// Else if one of them is null


### PR DESCRIPTION
There was a missing else there which causes that even when the credentials are correct and the username exists, it still returns an error.